### PR TITLE
Remove obsolete code in CmdHelp.java

### DIFF
--- a/src/pl/shockah/shocky/cmds/CmdHelp.java
+++ b/src/pl/shockah/shocky/cmds/CmdHelp.java
@@ -21,7 +21,6 @@ public class CmdHelp extends Command {
 		}
 		return sb.toString();
 	}
-	public boolean matches(PircBotX bot, EType type, String cmd) {return cmd.equals(command());}
 	
 	public void doCommand(PircBotX bot, EType type, CommandCallback callback, Channel channel, User sender, String message) {
 		String[] args = message.split(" ");


### PR DESCRIPTION
Was looking for how to add more different help strings in one command for UNO! and noticed that CmdHelp.java still had obsolete code.

You should probably put the matches() function back with a @Deprecated in front next time so you make sure to catch everything.
